### PR TITLE
Quality: Add Unit Tests for apis-web Controllers

### DIFF
--- a/src/test/java/jp/co/sony/csl/dcoes/apis/tools/web/util/DealGenerationTest.java
+++ b/src/test/java/jp/co/sony/csl/dcoes/apis/tools/web/util/DealGenerationTest.java
@@ -28,13 +28,11 @@ public class DealGenerationTest {
     @Mock
     private Vertx vertx;
 
-
     @Mock
     private HttpServerRequest req;  // fake request
 
     @Mock
     private HttpServerResponse res; // fake response
-
 
     @Mock
     private Logger log; 
@@ -50,184 +48,119 @@ public class DealGenerationTest {
         dealGeneration = new DealGeneration();
     }
 
-
-//should accept deal path 
-@Test
-public void shouldAcceptDealPath(){
-    // Arrange
-    when(req.path()).thenReturn("/deal");
-
-    // Act
-    boolean result = dealGeneration.canHandleRequest(req);
-
-    // Assert
-    assertTrue(result);
-}
-
-// returning 405 for unsupported methods
- @ParameterizedTest
-    @EnumSource(value = HttpMethod.class, names = {"GET", "POST"}, mode = EnumSource.Mode.EXCLUDE)
-    public void unsupportedMethodReturn405(HttpMethod unsupportedMethod) {
+    //should accept deal path 
+    @Test
+    public void shouldAcceptDealPath(){
         // Arrange
-        when(req.method()).thenReturn(unsupportedMethod);
-        when(req.response()).thenReturn(res);
-        when(res.setStatusCode(anyInt())).thenReturn(res);
-        
+        when(req.path()).thenReturn("/deal");
         // Act
-        dealGeneration.handleRequest(vertx, req, log);
-        
+        boolean result = dealGeneration.canHandleRequest(req);
         // Assert
-        verify(res).setStatusCode(405);
-        verify(res).end();
+        assertTrue(result);
     }
 
+    // returning 405 for unsupported methods
+    @ParameterizedTest
+        @EnumSource(value = HttpMethod.class, names = {"GET", "POST"}, mode = EnumSource.Mode.EXCLUDE)
+        public void unsupportedMethodReturn405(HttpMethod unsupportedMethod) {
+            // Arrange
+            when(req.method()).thenReturn(unsupportedMethod);
+            when(req.response()).thenReturn(res);
+            when(res.setStatusCode(anyInt())).thenReturn(res);
+            // Act
+            dealGeneration.handleRequest(vertx, req, log);
+            // Assert
+            verify(res).setStatusCode(405);
+            verify(res).end();
+        }
 
+    // Should reject Non-deal Paths
+    @ParameterizedTest
+    @ValueSource(strings = {"/status", "/users", "/health"})
+    public void shouldRejectNonDealPath(String path) {
+        // Arrange
+        when(req.path()).thenReturn(path);
+        // Act
+        boolean result = dealGeneration.canHandleRequest(req);
+        // Assert
+        assertFalse(result);
+    }
 
-// Should reject Non-deal Paths
-@ParameterizedTest
-@ValueSource(strings = {"/status", "/users", "/health"})
-public void shouldRejectNonDealPath(String path) {
-    // Arrange
-    when(req.path()).thenReturn(path);
+    // get method should return HTML
+    @Test
+    public void getShouldRetutnHTML(){
+        // Arrange
+        when(req.method()).thenReturn(HttpMethod.GET);
+        when(req.response()).thenReturn(res);
+        when(res.setChunked(true)).thenReturn(res);
+        when(res.putHeader("content-type", "text/html")).thenReturn(res);
+        when(res.write(anyString())).thenReturn(res);
+        // Act
+        dealGeneration.handleRequest(vertx, req, log);
+        // Assert
+        ArgumentCaptor<String> htmlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(res).write(htmlCaptor.capture());
+        String html = htmlCaptor.getValue();
+        assertTrue(html.contains("<html>"));
+    }
 
-    // Act
-    boolean result = dealGeneration.canHandleRequest(req);
-
-    // Assert
-    assertFalse(result);
-}
-
-
-
-// get method should return HTML
-@Test
-public void getShouldRetutnHTML(){
-    // Arrange
-    when(req.method()).thenReturn(HttpMethod.GET);
-    when(req.response()).thenReturn(res);
-    when(res.setChunked(true)).thenReturn(res);
-    when(res.putHeader("content-type", "text/html")).thenReturn(res);
-    when(res.write(anyString())).thenReturn(res);
-
-    // Act
-    dealGeneration.handleRequest(vertx, req, log);
-
-    // Assert
-    ArgumentCaptor<String> htmlCaptor = ArgumentCaptor.forClass(String.class);
-    verify(res).write(htmlCaptor.capture());
-    String html = htmlCaptor.getValue();
-    assertTrue(html.contains("<html>"));
-}
-
-// Should return 500 for invalid Json
-@Test
-public void postShouldReturn500ForInvalidJson() {
-    // Arrange
-    when(req.method()).thenReturn(HttpMethod.POST);
-    when(req.response()).thenReturn(res);
-    when(res.setChunked(true)).thenReturn(res);
-    when(res.putHeader(anyString(), anyString())).thenReturn(res);
-    when(res.setStatusCode(anyInt())).thenReturn(res);
-    when(req.getFormAttribute("json")).thenReturn("NOT_VALID_JSON");
-
-    // Act
-    dealGeneration.handleRequest(vertx, req, log);
-
-    // Assert
-    ArgumentCaptor<Handler<Void>> endHandlerCaptor = ArgumentCaptor.forClass(Handler.class);
-    verify(req).endHandler(endHandlerCaptor.capture());
-    endHandlerCaptor.getValue().handle(null);
-
-    verify(res).setStatusCode(500);
-}
-
-// Should send to eventBus on valid json
- @Test
-    public void postShouldSendToEventBusForValidJson() {
+    // Should return 500 for invalid Json
+    @Test
+    public void postShouldReturn500ForInvalidJson() {
+        // Arrange
         when(req.method()).thenReturn(HttpMethod.POST);
         when(req.response()).thenReturn(res);
         when(res.setChunked(true)).thenReturn(res);
         when(res.putHeader(anyString(), anyString())).thenReturn(res);
-        when(req.getFormAttribute("json")).thenReturn("{\"from\":\"nodeA\", \"to\":\"nodeB\"}"
-);
-        when(vertx.eventBus()).thenReturn(eventBus);
-
+        when(res.setStatusCode(anyInt())).thenReturn(res);
+        when(req.getFormAttribute("json")).thenReturn("NOT_VALID_JSON");
+        // Act
         dealGeneration.handleRequest(vertx, req, log);
-
+        // Assert
         ArgumentCaptor<Handler<Void>> endHandlerCaptor = ArgumentCaptor.forClass(Handler.class);
         verify(req).endHandler(endHandlerCaptor.capture());
         endHandlerCaptor.getValue().handle(null);
-
-        verify(eventBus).send(eq(ServiceAddress.Mediator.dealCreation()), any(JsonObject.class));
+        verify(res).setStatusCode(500);
     }
 
-// exceptions should throw 500
-@Test public void
-postException_ShouldReturn500(){
-    // Arrange
-    when(req.method()).thenReturn(HttpMethod.POST);
-    when(req.response()).thenReturn(res);
-    when(res.setChunked(true)).thenReturn(res);
-    when(res.putHeader(anyString(), anyString())).thenReturn(res);	
-    when(req.setExpectMultipart(true)).thenReturn(req);
+    // Should send to eventBus on valid json
+    @Test
+        public void postShouldSendToEventBusForValidJson() {
+            when(req.method()).thenReturn(HttpMethod.POST);
+            when(req.response()).thenReturn(res);
+            when(res.setChunked(true)).thenReturn(res);
+            when(res.putHeader(anyString(), anyString())).thenReturn(res);
+            when(req.getFormAttribute("json")).thenReturn("{\"from\":\"nodeA\", \"to\":\"nodeB\"}");
+            when(vertx.eventBus()).thenReturn(eventBus);
+            // Act
+            dealGeneration.handleRequest(vertx, req, log);
+            // Assert
+            ArgumentCaptor<Handler<Void>> endHandlerCaptor = ArgumentCaptor.forClass(Handler.class);
+            verify(req).endHandler(endHandlerCaptor.capture());
+            endHandlerCaptor.getValue().handle(null);
+            verify(eventBus).send(eq(ServiceAddress.Mediator.dealCreation()), any(JsonObject.class));
+        }
 
-
-    // Make getFormAttribute throw an exception
-    when(req.getFormAttribute(anyString())).thenThrow(new RuntimeException());
-
-    // Capture the endHandler
-    ArgumentCaptor<Handler> endHandlerCaptor = ArgumentCaptor.forClass(Handler.class);
-
-    // Act
-    dealGeneration.handleRequest(vertx, req, log);
-    verify(req).endHandler(endHandlerCaptor.capture());
-    
-    Handler capturedHandler = endHandlerCaptor.getValue();
-    capturedHandler.handle(null);
-
-
-    // Assert
-    verify(res).setStatusCode(500);
-    verify(res).setChunked(true);
-    verify(res).putHeader(anyString(),anyString());
-    verify(res).end(contains("exception"));
+    // exceptions should throw 500
+    @Test public void
+    postException_ShouldReturn500(){
+        // Arrange
+        when(req.method()).thenReturn(HttpMethod.POST);
+        when(req.response()).thenReturn(res);
+        when(res.setChunked(true)).thenReturn(res);
+        when(res.putHeader(anyString(), anyString())).thenReturn(res);	
+        when(req.setExpectMultipart(true)).thenReturn(req);
+        when(req.getFormAttribute(anyString())).thenThrow(new RuntimeException());
+        // Act
+        dealGeneration.handleRequest(vertx, req, log);
+        verify(req).endHandler(endHandlerCaptor.capture());
+        Handler capturedHandler = endHandlerCaptor.getValue();
+        capturedHandler.handle(null);
+        // Assert
+        ArgumentCaptor<Handler> endHandlerCaptor = ArgumentCaptor.forClass(Handler.class);
+        verify(res).setStatusCode(500);
+        verify(res).setChunked(true);
+        verify(res).putHeader(anyString(),anyString());
+        verify(res).end(contains("exception"));
+        }
     }
-
-
-}
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/test/java/jp/co/sony/csl/dcoes/apis/tools/web/util/DealGenerationTest.java
+++ b/src/test/java/jp/co/sony/csl/dcoes/apis/tools/web/util/DealGenerationTest.java
@@ -121,7 +121,7 @@ public void getShouldRetutnHTML(){
 
 // Should return 500 for invalid Json
 @Test
-public void shouldReturn500ForInvalidJson() {
+public void postShouldReturn500ForInvalidJson() {
     // Arrange
     when(req.method()).thenReturn(HttpMethod.POST);
     when(req.response()).thenReturn(res);
@@ -143,7 +143,7 @@ public void shouldReturn500ForInvalidJson() {
 
 // Should send to eventBus on valid json
  @Test
-    public void shouldSendToEventBusForValidJson() {
+    public void postShouldSendToEventBusForValidJson() {
         when(req.method()).thenReturn(HttpMethod.POST);
         when(req.response()).thenReturn(res);
         when(res.setChunked(true)).thenReturn(res);
@@ -160,9 +160,41 @@ public void shouldReturn500ForInvalidJson() {
 
         verify(eventBus).send(eq(ServiceAddress.Mediator.dealCreation()), any(JsonObject.class));
     }
+
+// exceptions should throw 500
+@Test public void
+postException_ShouldReturn500(){
+    // Arrange
+    when(req.method()).thenReturn(HttpMethod.POST);
+    when(req.response()).thenReturn(res);
+    when(res.setChunked(true)).thenReturn(res);
+    when(res.putHeader(anyString(), anyString())).thenReturn(res);	
+    when(req.setExpectMultipart(true)).thenReturn(req);
+
+
+    // Make getFormAttribute throw an exception
+    when(req.getFormAttribute(anyString())).thenThrow(new RuntimeException());
+
+    // Capture the endHandler
+    ArgumentCaptor<Handler> endHandlerCaptor = ArgumentCaptor.forClass(Handler.class);
+
+    // Act
+    dealGeneration.handleRequest(vertx, req, log);
+    verify(req).endHandler(endHandlerCaptor.capture());
+    
+    Handler capturedHandler = endHandlerCaptor.getValue();
+    capturedHandler.handle(null);
+
+
+    // Assert
+    verify(res).setStatusCode(500);
+    verify(res).setChunked(true);
+    verify(res).putHeader(anyString(),anyString());
+    verify(res).end(contains("exception"));
+    }
+
+
 }
-
-
 
 
 

--- a/src/test/java/jp/co/sony/csl/dcoes/apis/tools/web/util/DealGenerationTest.java
+++ b/src/test/java/jp/co/sony/csl/dcoes/apis/tools/web/util/DealGenerationTest.java
@@ -1,0 +1,201 @@
+package jp.co.sony.csl.dcoes.apis.tools.web.api_handler;
+
+import jp.co.sony.csl.dcoes.apis.tools.web.api_handler.DealGeneration;
+import jp.co.sony.csl.dcoes.apis.common.ServiceAddress;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.Handler;
+import io.vertx.core.json.JsonObject;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.*;
+import org.mockito.MockitoAnnotations;
+
+public class DealGenerationTest {
+
+    @Mock
+    private Vertx vertx;
+
+
+    @Mock
+    private HttpServerRequest req;  // fake request
+
+    @Mock
+    private HttpServerResponse res; // fake response
+
+
+    @Mock
+    private Logger log; 
+
+    private DealGeneration dealGeneration; 
+
+    @Mock
+    private EventBus eventBus;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        dealGeneration = new DealGeneration();
+    }
+
+
+//should accept deal path 
+@Test
+public void shouldAcceptDealPath(){
+    // Arrange
+    when(req.path()).thenReturn("/deal");
+
+    // Act
+    boolean result = dealGeneration.canHandleRequest(req);
+
+    // Assert
+    assertTrue(result);
+}
+
+// returning 405 for unsupported methods
+ @ParameterizedTest
+    @EnumSource(value = HttpMethod.class, names = {"GET", "POST"}, mode = EnumSource.Mode.EXCLUDE)
+    public void unsupportedMethodReturn405(HttpMethod unsupportedMethod) {
+        // Arrange
+        when(req.method()).thenReturn(unsupportedMethod);
+        when(req.response()).thenReturn(res);
+        when(res.setStatusCode(anyInt())).thenReturn(res);
+        
+        // Act
+        dealGeneration.handleRequest(vertx, req, log);
+        
+        // Assert
+        verify(res).setStatusCode(405);
+        verify(res).end();
+    }
+
+
+
+// Should reject Non-deal Paths
+@ParameterizedTest
+@ValueSource(strings = {"/status", "/users", "/health"})
+public void shouldRejectNonDealPath(String path) {
+    // Arrange
+    when(req.path()).thenReturn(path);
+
+    // Act
+    boolean result = dealGeneration.canHandleRequest(req);
+
+    // Assert
+    assertFalse(result);
+}
+
+
+
+// get method should return HTML
+@Test
+public void getShouldRetutnHTML(){
+    // Arrange
+    when(req.method()).thenReturn(HttpMethod.GET);
+    when(req.response()).thenReturn(res);
+    when(res.setChunked(true)).thenReturn(res);
+    when(res.putHeader("content-type", "text/html")).thenReturn(res);
+    when(res.write(anyString())).thenReturn(res);
+
+    // Act
+    dealGeneration.handleRequest(vertx, req, log);
+
+    // Assert
+    ArgumentCaptor<String> htmlCaptor = ArgumentCaptor.forClass(String.class);
+    verify(res).write(htmlCaptor.capture());
+    String html = htmlCaptor.getValue();
+    assertTrue(html.contains("<html>"));
+}
+
+// Should return 500 for invalid Json
+@Test
+public void shouldReturn500ForInvalidJson() {
+    // Arrange
+    when(req.method()).thenReturn(HttpMethod.POST);
+    when(req.response()).thenReturn(res);
+    when(res.setChunked(true)).thenReturn(res);
+    when(res.putHeader(anyString(), anyString())).thenReturn(res);
+    when(res.setStatusCode(anyInt())).thenReturn(res);
+    when(req.getFormAttribute("json")).thenReturn("NOT_VALID_JSON");
+
+    // Act
+    dealGeneration.handleRequest(vertx, req, log);
+
+    // Assert
+    ArgumentCaptor<Handler<Void>> endHandlerCaptor = ArgumentCaptor.forClass(Handler.class);
+    verify(req).endHandler(endHandlerCaptor.capture());
+    endHandlerCaptor.getValue().handle(null);
+
+    verify(res).setStatusCode(500);
+}
+
+// Should send to eventBus on valid json
+ @Test
+    public void shouldSendToEventBusForValidJson() {
+        when(req.method()).thenReturn(HttpMethod.POST);
+        when(req.response()).thenReturn(res);
+        when(res.setChunked(true)).thenReturn(res);
+        when(res.putHeader(anyString(), anyString())).thenReturn(res);
+        when(req.getFormAttribute("json")).thenReturn("{\"from\":\"nodeA\", \"to\":\"nodeB\"}"
+);
+        when(vertx.eventBus()).thenReturn(eventBus);
+
+        dealGeneration.handleRequest(vertx, req, log);
+
+        ArgumentCaptor<Handler<Void>> endHandlerCaptor = ArgumentCaptor.forClass(Handler.class);
+        verify(req).endHandler(endHandlerCaptor.capture());
+        endHandlerCaptor.getValue().handle(null);
+
+        verify(eventBus).send(eq(ServiceAddress.Mediator.dealCreation()), any(JsonObject.class));
+    }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/test/java/jp/co/sony/csl/dcoes/apis/tools/web/util/ErrorGenerationTest.java
+++ b/src/test/java/jp/co/sony/csl/dcoes/apis/tools/web/util/ErrorGenerationTest.java
@@ -1,0 +1,213 @@
+package jp.co.sony.csl.dcoes.apis.tools.web.api_handler;
+
+import jp.co.sony.csl.dcoes.apis.tools.web.api_handler.ErrorGeneration;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.*;
+import org.mockito.MockitoAnnotations;
+
+
+public class ErrorGenerationTest{
+    @Mock
+    private Vertx vertx;
+
+
+    @Mock
+    private HttpServerRequest req;
+
+    @Mock
+    private HttpServerResponse res; // fake response
+
+    @Mock
+    private Logger log; 
+
+    private ErrorGeneration errorGeneration;
+
+    @Mock
+    private EventBus eventBus;
+
+    @BeforeEach
+    public void setUp() {
+    MockitoAnnotations.openMocks(this);
+    errorGeneration = new ErrorGeneration();
+    }
+
+    //should accept error path 
+    @Test
+    public void shouldAcceptErrorPath(){
+    // Arrange
+    when(req.path()).thenReturn("/error");
+
+    // Act
+    boolean result = errorGeneration.canHandleRequest(req);
+
+    // Assert
+    assertTrue(result);
+}
+
+
+// Should reject non-error Paths
+@ParameterizedTest
+@ValueSource(strings = {"/status","/users","/health"})
+public void shouldRejectNonLogPath(String path){
+    // Arrange
+    when(req.path()).thenReturn(path);
+
+    // Act
+    boolean result = errorGeneration.canHandleRequest(req);
+
+    // Assert
+    assertFalse(result);
+}
+
+// returning 405 for unsupported methods
+@ParameterizedTest
+    @EnumSource(value = HttpMethod.class, names ={"GET","POST"},mode = EnumSource.Mode.Exclude)
+    public void unsupportedMethodReturn405(HttpMethod unsupportedMethod){
+        // Arrange
+        when(req.method()).thenReturn(unsupportedMethod);
+        when(req.response()).thenReturn(res);
+        when(res.setStatusCode(anyInt())).thenReturn(res);
+        
+        // Act
+        errorGeneration.handleRequest(vertx,req,log);
+
+        // Assert
+        verify(res).setStatusCode(405);
+        verify(res).end();
+    }
+
+
+// GET method should return HTML
+@Test
+public void getShouldRetutnHTML(){
+    // Arrange
+    when(req.method()).thenReturn(HttpMethod.GET);
+    when(req.response()).thenReturn(res);
+    when(res.setChunked(true)).thenReturn(res);
+    when(res.putHeader("content-type","text/html")).thenReturn(res);
+    when(res.write(anyString())).thenReturn(res);
+    
+    //Act
+    errorGeneration.handleRequest(vertx, req, log);
+
+    // Assert
+    ArgumentCaptor<String> htmlCaptor = ArgumentCaptor.forClass(String.class);
+    verify(res).write(htmlCaptor.capture());
+    String html = htmlCaptor.getValue();
+    assertTrue(html.contains("<html>"));
+}
+
+// POST method, with valid error-data.
+@Test 
+public void postWithValidErrorData_ShouldReportError() {
+    // Arrange
+    when(req.method()).thenReturn(HttpMethod.POST);
+    when(req.response()).thenReturn(res);
+    when(res.setChunked(true)).thenReturn(res);
+    when(res.putHeader(anyString(), anyString())).thenReturn(res);
+    when(res.end(anyString())).thenReturn(res);
+
+    when(req.getFormAttribute("unitId")).thenReturn("unit-1");
+    when(req.getFormAttribute("category")).thenReturn("USER");
+    when(req.getFormAttribute("extent")).thenReturn("LOCAL");
+    when(req.getFormAttribute("level")).thenReturn("ERROR");
+    when(req.getFormAttribute("message")).thenReturn("Test error");
+
+    ArgumentCaptor<Handler> endHandlerCaptor = ArgumentCaptor.forClass(Handler.class);
+    
+    // Act
+    errorGeneration.handleRequest(vertx, req, log);
+    verify(req).endHandler(endHandlerCaptor.capture());
+    
+    Handler capturedHandler = endHandlerCaptor.getValue();
+    capturedHandler.handle(null);
+
+    // Assert
+    verify(res).setChunked(true);
+    verify(res).putHeader("content-type", "text/plain");
+    verify(res).end(contains("publishing error"));
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+@Test public void
+postException_ShouldReturn500(){
+    // Arrange
+    when(req.method()).thenReturn(HttpMethod.POST);
+    when(req.response()).thenReturn(res);
+    when(req.setExpectMultipart(true)).thenReturn(req);
+    when(res.setChunked(true)).thenReturn(res);
+    when(res.putHeader(anyString(), anyString())).thenReturn(res);	
+    when(res.setStatusCode(anyInt())).thenReturn(res);
+    when(res.end(anyString())).thenReturn(res);
+
+
+    // Make getFormAttribute throw an exception
+    when(req.getFormAttribute(anyString())).thenThrow(new RuntimeException());
+
+    // Capture the endHandler
+    ArgumentCaptor<Handler> endHandlerCaptor = ArgumentCaptor.forClass(Handler.class);
+
+    // Act
+    errorGeneration.handleRequest(vertx, req, log);
+    verify(req).endHandler(endHandlerCaptor.capture());
+    
+    Handler capturedHandler = endHandlerCaptor.getValue();
+    capturedHandler.handle(null);
+
+
+    // Assert
+    verify(res).setStatusCode(500);
+    verify(res).end(contains("exception"));
+    }
+
+
+}

--- a/src/test/java/jp/co/sony/csl/dcoes/apis/tools/web/util/ErrorGenerationTest.java
+++ b/src/test/java/jp/co/sony/csl/dcoes/apis/tools/web/util/ErrorGenerationTest.java
@@ -24,11 +24,9 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.*;
 import org.mockito.MockitoAnnotations;
 
-
 public class ErrorGenerationTest{
     @Mock
     private Vertx vertx;
-
 
     @Mock
     private HttpServerRequest req;
@@ -55,159 +53,103 @@ public class ErrorGenerationTest{
     public void shouldAcceptErrorPath(){
     // Arrange
     when(req.path()).thenReturn("/error");
-
     // Act
     boolean result = errorGeneration.canHandleRequest(req);
-
     // Assert
     assertTrue(result);
 }
 
-
-// Should reject non-error Paths
-@ParameterizedTest
-@ValueSource(strings = {"/status","/users","/health"})
-public void shouldRejectNonLogPath(String path){
-    // Arrange
-    when(req.path()).thenReturn(path);
-
-    // Act
-    boolean result = errorGeneration.canHandleRequest(req);
-
-    // Assert
-    assertFalse(result);
-}
-
-// returning 405 for unsupported methods
-@ParameterizedTest
-    @EnumSource(value = HttpMethod.class, names ={"GET","POST"},mode = EnumSource.Mode.Exclude)
-    public void unsupportedMethodReturn405(HttpMethod unsupportedMethod){
+    // Should reject non-error Paths
+    @ParameterizedTest
+    @ValueSource(strings = {"/status","/users","/health"})
+    public void shouldRejectNonLogPath(String path){
         // Arrange
-        when(req.method()).thenReturn(unsupportedMethod);
-        when(req.response()).thenReturn(res);
-        when(res.setStatusCode(anyInt())).thenReturn(res);
-        
+        when(req.path()).thenReturn(path);
         // Act
-        errorGeneration.handleRequest(vertx,req,log);
-
+        boolean result = errorGeneration.canHandleRequest(req);
         // Assert
-        verify(res).setStatusCode(405);
-        verify(res).end();
+        assertFalse(result);
     }
 
+    // returning 405 for unsupported methods
+    @ParameterizedTest
+        @EnumSource(value = HttpMethod.class, names ={"GET","POST"},mode = EnumSource.Mode.Exclude)
+        public void unsupportedMethodReturn405(HttpMethod unsupportedMethod){
+            // Arrange
+            when(req.method()).thenReturn(unsupportedMethod);
+            when(req.response()).thenReturn(res);
+            when(res.setStatusCode(anyInt())).thenReturn(res);
+            // Act
+            errorGeneration.handleRequest(vertx,req,log);
+            // Assert
+            verify(res).setStatusCode(405);
+            verify(res).end();
+        }
 
-// GET method should return HTML
-@Test
-public void getShouldRetutnHTML(){
-    // Arrange
-    when(req.method()).thenReturn(HttpMethod.GET);
-    when(req.response()).thenReturn(res);
-    when(res.setChunked(true)).thenReturn(res);
-    when(res.putHeader("content-type","text/html")).thenReturn(res);
-    when(res.write(anyString())).thenReturn(res);
-    
-    //Act
-    errorGeneration.handleRequest(vertx, req, log);
-
-    // Assert
-    ArgumentCaptor<String> htmlCaptor = ArgumentCaptor.forClass(String.class);
-    verify(res).write(htmlCaptor.capture());
-    String html = htmlCaptor.getValue();
-    assertTrue(html.contains("<html>"));
-}
-
-// POST method, with valid error-data.
-@Test 
-public void postWithValidErrorData_ShouldReportError() {
-    // Arrange
-    when(req.method()).thenReturn(HttpMethod.POST);
-    when(req.response()).thenReturn(res);
-    when(res.setChunked(true)).thenReturn(res);
-    when(res.putHeader(anyString(), anyString())).thenReturn(res);
-    when(res.end(anyString())).thenReturn(res);
-
-    when(req.getFormAttribute("unitId")).thenReturn("unit-1");
-    when(req.getFormAttribute("category")).thenReturn("USER");
-    when(req.getFormAttribute("extent")).thenReturn("LOCAL");
-    when(req.getFormAttribute("level")).thenReturn("ERROR");
-    when(req.getFormAttribute("message")).thenReturn("Test error");
-
-    ArgumentCaptor<Handler> endHandlerCaptor = ArgumentCaptor.forClass(Handler.class);
-    
-    // Act
-    errorGeneration.handleRequest(vertx, req, log);
-    verify(req).endHandler(endHandlerCaptor.capture());
-    
-    Handler capturedHandler = endHandlerCaptor.getValue();
-    capturedHandler.handle(null);
-
-    // Assert
-    verify(res).setChunked(true);
-    verify(res).putHeader("content-type", "text/plain");
-    verify(res).end(contains("publishing error"));
-}
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-@Test public void
-postException_ShouldReturn500(){
-    // Arrange
-    when(req.method()).thenReturn(HttpMethod.POST);
-    when(req.response()).thenReturn(res);
-    when(req.setExpectMultipart(true)).thenReturn(req);
-    when(res.setChunked(true)).thenReturn(res);
-    when(res.putHeader(anyString(), anyString())).thenReturn(res);	
-    when(res.setStatusCode(anyInt())).thenReturn(res);
-    when(res.end(anyString())).thenReturn(res);
-
-
-    // Make getFormAttribute throw an exception
-    when(req.getFormAttribute(anyString())).thenThrow(new RuntimeException());
-
-    // Capture the endHandler
-    ArgumentCaptor<Handler> endHandlerCaptor = ArgumentCaptor.forClass(Handler.class);
-
-    // Act
-    errorGeneration.handleRequest(vertx, req, log);
-    verify(req).endHandler(endHandlerCaptor.capture());
-    
-    Handler capturedHandler = endHandlerCaptor.getValue();
-    capturedHandler.handle(null);
-
-
-    // Assert
-    verify(res).setStatusCode(500);
-    verify(res).end(contains("exception"));
+    // GET method should return HTML
+    @Test
+    public void getShouldRetutnHTML(){
+        // Arrange
+        when(req.method()).thenReturn(HttpMethod.GET);
+        when(req.response()).thenReturn(res);
+        when(res.setChunked(true)).thenReturn(res);
+        when(res.putHeader("content-type","text/html")).thenReturn(res);
+        when(res.write(anyString())).thenReturn(res);
+        //Act
+        errorGeneration.handleRequest(vertx, req, log);
+        // Assert
+        ArgumentCaptor<String> htmlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(res).write(htmlCaptor.capture());
+        String html = htmlCaptor.getValue();
+        assertTrue(html.contains("<html>"));
     }
 
+    // POST method, with valid error-data.
+    @Test 
+    public void postWithValidErrorData_ShouldReportError() {
+        // Arrange
+        when(req.method()).thenReturn(HttpMethod.POST);
+        when(req.response()).thenReturn(res);
+        when(res.setChunked(true)).thenReturn(res);
+        when(res.putHeader(anyString(), anyString())).thenReturn(res);
+        when(res.end(anyString())).thenReturn(res);
+        when(req.getFormAttribute("unitId")).thenReturn("unit-1");
+        when(req.getFormAttribute("category")).thenReturn("USER");
+        when(req.getFormAttribute("extent")).thenReturn("LOCAL");
+        when(req.getFormAttribute("level")).thenReturn("ERROR");
+        when(req.getFormAttribute("message")).thenReturn("Test error");
+        ArgumentCaptor<Handler> endHandlerCaptor = ArgumentCaptor.forClass(Handler.class);
+        // Act
+        errorGeneration.handleRequest(vertx, req, log);
+        verify(req).endHandler(endHandlerCaptor.capture());
+        Handler capturedHandler = endHandlerCaptor.getValue();
+        capturedHandler.handle(null);
+        // Assert
+        verify(res).setChunked(true);
+        verify(res).putHeader("content-type", "text/plain");
+        verify(res).end(contains("publishing error"));
+    }
 
-}
+    // exception should throw 500
+    @Test public void
+    postException_ShouldReturn500(){
+        // Arrange
+        when(req.method()).thenReturn(HttpMethod.POST);
+        when(req.response()).thenReturn(res);
+        when(req.setExpectMultipart(true)).thenReturn(req);
+        when(res.setChunked(true)).thenReturn(res);
+        when(res.putHeader(anyString(), anyString())).thenReturn(res);	
+        when(res.setStatusCode(anyInt())).thenReturn(res);
+        when(res.end(anyString())).thenReturn(res);
+        when(req.getFormAttribute(anyString())).thenThrow(new RuntimeException());
+        ArgumentCaptor<Handler> endHandlerCaptor = ArgumentCaptor.forClass(Handler.class);
+        // Act
+        errorGeneration.handleRequest(vertx, req, log);
+        verify(req).endHandler(endHandlerCaptor.capture());
+        Handler capturedHandler = endHandlerCaptor.getValue();
+        capturedHandler.handle(null);
+        // Assert
+        verify(res).setStatusCode(500);
+        verify(res).end(contains("exception"));
+        }
+    }

--- a/src/test/java/jp/co/sony/csl/dcoes/apis/tools/web/util/LogConfigurationTest.java
+++ b/src/test/java/jp/co/sony/csl/dcoes/apis/tools/web/util/LogConfigurationTest.java
@@ -1,0 +1,229 @@
+package jp.co.sony.csl.dcoes.apis.tools.web.api_handler;
+
+import jp.co.sony.csl.dcoes.apis.tools.web.api_handler.LogConfiguration;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.*;
+import org.mockito.MockitoAnnotations;
+
+public class LogConfigurationTest{
+    @Mock
+    private Vertx vertx;
+
+
+
+    @Mock
+    private HttpServerRequest req;
+
+    @Mock
+    private HttpServerResponse res; // fake response
+
+    @Mock
+    private Logger log; 
+
+    private LogConfiguration logConfiguration;
+
+    @Mock
+    private EventBus eventBus;
+
+    @BeforeEach
+    public void setUp() {
+    MockitoAnnotations.openMocks(this);
+    logConfiguration = new LogConfiguration();
+    }
+
+    //should accept log path 
+    @Test
+    public void shouldAcceptLogPath(){
+    // Arrange
+    when(req.path()).thenReturn("/log");
+
+    // Act
+    boolean result = logConfiguration.canHandleRequest(req);
+
+    // Assert
+    assertTrue(result);
+}
+
+
+// returning 405 for unsupported methods
+@ParameterizedTest
+    @EnumSource(value = HttpMethod.class, names ={"GET","POST"},mode = EnumSource.Mode.Exclude)
+    public void unsupportedMethodReturn405(HttpMethod unsupportedMethod){
+        // Arrange
+        when(req.method()).thenReturn(unsupportedMethod);
+        when(req.response()).thenReturn(res);
+        when(res.setStatusCode(anyInt())).thenReturn(res);
+        
+        // Act
+        logConfiguration.handleRequest(vertx,req,log);
+
+        // Assert
+        verify(res).setStatusCode(405);
+        verify(res).end();
+    }
+
+// Should reject Non-log Paths
+@ParameterizedTest
+@ValueSource(strings = {"/status","/users","/health"})
+public void shouldRejectNonLogPath(String path){
+    // Arrange
+    when(req.path()).thenReturn(path);
+
+    // Act
+    boolean result = logConfiguration.canHandleRequest(req);
+
+    // Assert
+    assertFalse(result);
+}
+
+// GET method should return HTML
+@Test
+public void getShouldRetutnHTML(){
+    // Arrange
+    when(req.method()).thenReturn(HttpMethod.GET);
+    when(req.response()).thenReturn(res);
+    when(res.setChunked(true)).thenReturn(res);
+    when(res.putHeader("content-type","text/html")).thenReturn(res);
+    when(res.write(anyString())).thenReturn(res);
+    
+    //Act
+    logConfiguration.handleRequest(vertx, req, log);
+
+    // Assert
+    ArgumentCaptor<String> htmlCaptor = ArgumentCaptor.forClass(String.class);
+    verify(res).write(htmlCaptor.capture());
+    String html = htmlCaptor.getValue();
+    assertTrue(html.contains("<html>"));
+}
+
+
+@Test public void postWithMulticastHandler_ShouldPublishToEventBus() {
+    // Arrange
+    when(vertx.eventBus()).thenReturn(eventBus); 
+    when(req.method()).thenReturn(HttpMethod.POST);
+    when(req.response()).thenReturn(res);
+    when(res.setChunked(true)).thenReturn(res);
+    when(res.putHeader(anyString(), anyString())).thenReturn(res);
+     when(res.end(anyString())).thenReturn(res);
+
+    when(req.getFormAttribute("handler")).thenReturn("Multicast");
+    when(req.getFormAttribute("level")).thenReturn("DEBUG");
+
+    // Capture the endHandler
+    ArgumentCaptor<Handler> endHandlerCaptor = ArgumentCaptor.forClass(Handler.class);
+    
+    // Act - register the handler
+    logConfiguration.handleRequest(vertx, req, log);
+    
+    // Verify the endHandler was registered
+    verify(req).endHandler(endHandlerCaptor.capture());
+    
+    // Act - trigger it manually (simulate form upload finishing)
+    Handler capturedHandler = endHandlerCaptor.getValue();
+    capturedHandler.handle(null);
+
+    // Assert
+    verify(eventBus).publish(ServiceAddress.multicastLogHandlerLevel(), "DEBUG");
+
+    verify(res).end(contains("publishing new multicast log level"));
+
+}
+
+@Test public void postWithoutMulticastHandler_ShouldReturn500() {
+    // Arrange
+    when(vertx.eventBus()).thenReturn(eventBus); 
+    when(req.method()).thenReturn(HttpMethod.POST);
+    when(req.response()).thenReturn(res);
+    when(res.setChunked(true)).thenReturn(res);
+    when(res.putHeader(anyString(), anyString())).thenReturn(res);
+     when(res.end(anyString())).thenReturn(res);
+
+    when(req.getFormAttribute("handler")).thenReturn("Unknown");
+    when(req.getFormAttribute("level")).thenReturn("DEBUG");
+
+    // Capture the endHandler
+    ArgumentCaptor<Handler> endHandlerCaptor = ArgumentCaptor.forClass(Handler.class);
+
+    // Act
+    logConfiguration.handleRequest(vertx, req, log);
+    verify(req).endHandler(endHandlerCaptor.capture());
+    
+    Handler capturedHandler = endHandlerCaptor.getValue();
+    capturedHandler.handle(null);
+
+    // Assert
+    verify(res).setStatusCode(500);
+    verify(res).end(contains("exception"));
+}
+
+@Test public void
+postThrowinfException_ShouldReturn500(){
+    // Arrange
+    when(req.method()).thenReturn(HttpMethod.POST);
+    when(req.response()).thenReturn(res);
+    when(res.setChunked(true)).thenReturn(res);
+    when(res.putHeader(anyString(), anyString())).thenReturn(res);	
+    when(req.setExpectMultipart(true)).thenReturn(req);
+
+
+    // Make getFormAttribute throw an exception
+    when(req.getFormAttribute(anyString())).thenThrow(new RuntimeException());
+
+    // Capture the endHandler
+    ArgumentCaptor<Handler> endHandlerCaptor = ArgumentCaptor.forClass(Handler.class);
+
+    // Act
+    logConfiguration.handleRequest(vertx, req, log);
+    verify(req).endHandler(endHandlerCaptor.capture());
+    
+    Handler capturedHandler = endHandlerCaptor.getValue();
+    capturedHandler.handle(null);
+
+
+    // Assert
+    verify(res).setStatusCode(500);
+    verify(res).end(contains("unknown log handler"));
+
+
+    }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+}
+
+

--- a/src/test/java/jp/co/sony/csl/dcoes/apis/tools/web/util/LogConfigurationTest.java
+++ b/src/test/java/jp/co/sony/csl/dcoes/apis/tools/web/util/LogConfigurationTest.java
@@ -28,8 +28,6 @@ public class LogConfigurationTest{
     @Mock
     private Vertx vertx;
 
-
-
     @Mock
     private HttpServerRequest req;
 
@@ -115,7 +113,7 @@ public void getShouldRetutnHTML(){
     assertTrue(html.contains("<html>"));
 }
 
-
+// post with multicast handler should publish to eventbus
 @Test public void postWithMulticastHandler_ShouldPublishToEventBus() {
     // Arrange
     when(vertx.eventBus()).thenReturn(eventBus); 
@@ -148,6 +146,7 @@ public void getShouldRetutnHTML(){
 
 }
 
+// post without multicast handler should return 500
 @Test public void postWithoutMulticastHandler_ShouldReturn500() {
     // Arrange
     when(vertx.eventBus()).thenReturn(eventBus); 
@@ -175,8 +174,9 @@ public void getShouldRetutnHTML(){
     verify(res).end(contains("exception"));
 }
 
+// exception should throw 500
 @Test public void
-postThrowinfException_ShouldReturn500(){
+postException_ShouldReturn500(){
     // Arrange
     when(req.method()).thenReturn(HttpMethod.POST);
     when(req.response()).thenReturn(res);
@@ -202,28 +202,7 @@ postThrowinfException_ShouldReturn500(){
     // Assert
     verify(res).setStatusCode(500);
     verify(res).end(contains("unknown log handler"));
-
-
     }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 }
 
 

--- a/src/test/java/jp/co/sony/csl/dcoes/apis/tools/web/util/LogConfigurationTest.java
+++ b/src/test/java/jp/co/sony/csl/dcoes/apis/tools/web/util/LogConfigurationTest.java
@@ -53,156 +53,121 @@ public class LogConfigurationTest{
     public void shouldAcceptLogPath(){
     // Arrange
     when(req.path()).thenReturn("/log");
-
     // Act
     boolean result = logConfiguration.canHandleRequest(req);
-
     // Assert
     assertTrue(result);
-}
+    }
 
+    // returning 405 for unsupported methods
+    @ParameterizedTest
+        @EnumSource(value = HttpMethod.class, names ={"GET","POST"},mode = EnumSource.Mode.Exclude)
+        public void unsupportedMethodReturn405(HttpMethod unsupportedMethod){
+            // Arrange
+            when(req.method()).thenReturn(unsupportedMethod);
+            when(req.response()).thenReturn(res);
+            when(res.setStatusCode(anyInt())).thenReturn(res);
+            // Act
+            logConfiguration.handleRequest(vertx,req,log);
+            // Assert
+            verify(res).setStatusCode(405);
+            verify(res).end();
+        }
 
-// returning 405 for unsupported methods
-@ParameterizedTest
-    @EnumSource(value = HttpMethod.class, names ={"GET","POST"},mode = EnumSource.Mode.Exclude)
-    public void unsupportedMethodReturn405(HttpMethod unsupportedMethod){
+    // Should reject Non-log Paths
+    @ParameterizedTest
+    @ValueSource(strings = {"/status","/users","/health"})
+    public void shouldRejectNonLogPath(String path){
         // Arrange
-        when(req.method()).thenReturn(unsupportedMethod);
-        when(req.response()).thenReturn(res);
-        when(res.setStatusCode(anyInt())).thenReturn(res);
-        
+        when(req.path()).thenReturn(path);
         // Act
-        logConfiguration.handleRequest(vertx,req,log);
-
+        boolean result = logConfiguration.canHandleRequest(req);
         // Assert
-        verify(res).setStatusCode(405);
-        verify(res).end();
+        assertFalse(result);
     }
 
-// Should reject Non-log Paths
-@ParameterizedTest
-@ValueSource(strings = {"/status","/users","/health"})
-public void shouldRejectNonLogPath(String path){
-    // Arrange
-    when(req.path()).thenReturn(path);
-
-    // Act
-    boolean result = logConfiguration.canHandleRequest(req);
-
-    // Assert
-    assertFalse(result);
-}
-
-// GET method should return HTML
-@Test
-public void getShouldRetutnHTML(){
-    // Arrange
-    when(req.method()).thenReturn(HttpMethod.GET);
-    when(req.response()).thenReturn(res);
-    when(res.setChunked(true)).thenReturn(res);
-    when(res.putHeader("content-type","text/html")).thenReturn(res);
-    when(res.write(anyString())).thenReturn(res);
-    
-    //Act
-    logConfiguration.handleRequest(vertx, req, log);
-
-    // Assert
-    ArgumentCaptor<String> htmlCaptor = ArgumentCaptor.forClass(String.class);
-    verify(res).write(htmlCaptor.capture());
-    String html = htmlCaptor.getValue();
-    assertTrue(html.contains("<html>"));
-}
-
-// post with multicast handler should publish to eventbus
-@Test public void postWithMulticastHandler_ShouldPublishToEventBus() {
-    // Arrange
-    when(vertx.eventBus()).thenReturn(eventBus); 
-    when(req.method()).thenReturn(HttpMethod.POST);
-    when(req.response()).thenReturn(res);
-    when(res.setChunked(true)).thenReturn(res);
-    when(res.putHeader(anyString(), anyString())).thenReturn(res);
-     when(res.end(anyString())).thenReturn(res);
-
-    when(req.getFormAttribute("handler")).thenReturn("Multicast");
-    when(req.getFormAttribute("level")).thenReturn("DEBUG");
-
-    // Capture the endHandler
-    ArgumentCaptor<Handler> endHandlerCaptor = ArgumentCaptor.forClass(Handler.class);
-    
-    // Act - register the handler
-    logConfiguration.handleRequest(vertx, req, log);
-    
-    // Verify the endHandler was registered
-    verify(req).endHandler(endHandlerCaptor.capture());
-    
-    // Act - trigger it manually (simulate form upload finishing)
-    Handler capturedHandler = endHandlerCaptor.getValue();
-    capturedHandler.handle(null);
-
-    // Assert
-    verify(eventBus).publish(ServiceAddress.multicastLogHandlerLevel(), "DEBUG");
-
-    verify(res).end(contains("publishing new multicast log level"));
-
-}
-
-// post without multicast handler should return 500
-@Test public void postWithoutMulticastHandler_ShouldReturn500() {
-    // Arrange
-    when(vertx.eventBus()).thenReturn(eventBus); 
-    when(req.method()).thenReturn(HttpMethod.POST);
-    when(req.response()).thenReturn(res);
-    when(res.setChunked(true)).thenReturn(res);
-    when(res.putHeader(anyString(), anyString())).thenReturn(res);
-     when(res.end(anyString())).thenReturn(res);
-
-    when(req.getFormAttribute("handler")).thenReturn("Unknown");
-    when(req.getFormAttribute("level")).thenReturn("DEBUG");
-
-    // Capture the endHandler
-    ArgumentCaptor<Handler> endHandlerCaptor = ArgumentCaptor.forClass(Handler.class);
-
-    // Act
-    logConfiguration.handleRequest(vertx, req, log);
-    verify(req).endHandler(endHandlerCaptor.capture());
-    
-    Handler capturedHandler = endHandlerCaptor.getValue();
-    capturedHandler.handle(null);
-
-    // Assert
-    verify(res).setStatusCode(500);
-    verify(res).end(contains("exception"));
-}
-
-// exception should throw 500
-@Test public void
-postException_ShouldReturn500(){
-    // Arrange
-    when(req.method()).thenReturn(HttpMethod.POST);
-    when(req.response()).thenReturn(res);
-    when(res.setChunked(true)).thenReturn(res);
-    when(res.putHeader(anyString(), anyString())).thenReturn(res);	
-    when(req.setExpectMultipart(true)).thenReturn(req);
-
-
-    // Make getFormAttribute throw an exception
-    when(req.getFormAttribute(anyString())).thenThrow(new RuntimeException());
-
-    // Capture the endHandler
-    ArgumentCaptor<Handler> endHandlerCaptor = ArgumentCaptor.forClass(Handler.class);
-
-    // Act
-    logConfiguration.handleRequest(vertx, req, log);
-    verify(req).endHandler(endHandlerCaptor.capture());
-    
-    Handler capturedHandler = endHandlerCaptor.getValue();
-    capturedHandler.handle(null);
-
-
-    // Assert
-    verify(res).setStatusCode(500);
-    verify(res).end(contains("unknown log handler"));
+    // GET method should return HTML
+    @Test
+    public void getShouldRetutnHTML(){
+        // Arrange
+        when(req.method()).thenReturn(HttpMethod.GET);
+        when(req.response()).thenReturn(res);
+        when(res.setChunked(true)).thenReturn(res);
+        when(res.putHeader("content-type","text/html")).thenReturn(res);
+        when(res.write(anyString())).thenReturn(res);
+        //Act
+        logConfiguration.handleRequest(vertx, req, log);
+        // Assert
+        ArgumentCaptor<String> htmlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(res).write(htmlCaptor.capture());
+        String html = htmlCaptor.getValue();
+        assertTrue(html.contains("<html>"));
     }
-}
+
+    // post with multicast handler should publish to eventbus
+    @Test public void postWithMulticastHandler_ShouldPublishToEventBus() {
+        // Arrange
+        when(vertx.eventBus()).thenReturn(eventBus); 
+        when(req.method()).thenReturn(HttpMethod.POST);
+        when(req.response()).thenReturn(res);
+        when(res.setChunked(true)).thenReturn(res);
+        when(res.putHeader(anyString(), anyString())).thenReturn(res);
+        when(res.end(anyString())).thenReturn(res);
+        when(req.getFormAttribute("handler")).thenReturn("Multicast");
+        when(req.getFormAttribute("level")).thenReturn("DEBUG");
+        ArgumentCaptor<Handler> endHandlerCaptor = ArgumentCaptor.forClass(Handler.class);
+        // Act 
+        logConfiguration.handleRequest(vertx, req, log);
+        verify(req).endHandler(endHandlerCaptor.capture());
+        Handler capturedHandler = endHandlerCaptor.getValue();
+        capturedHandler.handle(null);
+        // Assert
+        verify(eventBus).publish(ServiceAddress.multicastLogHandlerLevel(), "DEBUG");
+        verify(res).end(contains("publishing new multicast log level"));
+    }
+
+    // post without multicast handler should return 500
+    @Test public void postWithoutMulticastHandler_ShouldReturn500() {
+        // Arrange
+        when(vertx.eventBus()).thenReturn(eventBus); 
+        when(req.method()).thenReturn(HttpMethod.POST);
+        when(req.response()).thenReturn(res);
+        when(res.setChunked(true)).thenReturn(res);
+        when(res.putHeader(anyString(), anyString())).thenReturn(res);
+        when(res.end(anyString())).thenReturn(res);
+        when(req.getFormAttribute("handler")).thenReturn("Unknown");
+        when(req.getFormAttribute("level")).thenReturn("DEBUG");
+        ArgumentCaptor<Handler> endHandlerCaptor = ArgumentCaptor.forClass(Handler.class);
+        // Act
+        logConfiguration.handleRequest(vertx, req, log);
+        verify(req).endHandler(endHandlerCaptor.capture());
+        Handler capturedHandler = endHandlerCaptor.getValue();
+        capturedHandler.handle(null);
+        // Assert
+        verify(res).setStatusCode(500);
+        verify(res).end(contains("exception"));
+    }
+
+    // exception should throw 500
+    @Test public void
+    postException_ShouldReturn500(){
+        // Arrange
+        when(req.method()).thenReturn(HttpMethod.POST);
+        when(req.response()).thenReturn(res);
+        when(res.setChunked(true)).thenReturn(res);
+        when(res.putHeader(anyString(), anyString())).thenReturn(res);	
+        when(req.setExpectMultipart(true)).thenReturn(req);
+        when(req.getFormAttribute(anyString())).thenThrow(new RuntimeException());
+        ArgumentCaptor<Handler> endHandlerCaptor = ArgumentCaptor.forClass(Handler.class);
+        // Act
+        logConfiguration.handleRequest(vertx, req, log);
+        verify(req).endHandler(endHandlerCaptor.capture());
+        Handler capturedHandler = endHandlerCaptor.getValue();
+        capturedHandler.handle(null);
+        // Assert
+        verify(res).setStatusCode(500);
+        verify(res).end(contains("unknown log handler"));
+        }
+    }
 
 


### PR DESCRIPTION
Added comprehensive unit test coverage for three critical API handlers in apis-web, directly addressing issue #93's requirement to improve test coverage.

**Tests Added:**
- DealGenerationTest (7 tests) - validates deal creation endpoint, JSON parsing, EventBus messaging
- LogConfigurationTest (7 tests) - validates log level configuration, multicast handler support
- ErrorGenerationTest (6 tests) - validates error generation endpoint, form field handling

**Test Coverage:**
Each test class covers:
- Path matching validation (accepts correct paths, rejects others)
- HTTP method handling (GET returns HTML form, POST processes data, others return 405)
- Happy path scenarios (valid data successfully processed)
- Error scenarios (invalid data, malformed JSON, exceptions return 500)
- Mocked external dependencies (EventBus, HTTP request/response, Logger)

**Dependencies Required:**
```xml
<dependency>
    <groupId>org.junit.jupiter</groupId>
    <artifactId>junit-jupiter-api</artifactId>
    <version>5.9.3</version>
    <scope>test</scope>
</dependency>
<dependency>
    <groupId>org.junit.jupiter</groupId>
    <artifactId>junit-jupiter-engine</artifactId>
    <version>5.9.3</version>
    <scope>test</scope>
</dependency>
<dependency>
    <groupId>org.mockito</groupId>
    <artifactId>mockito-core</artifactId>
    <version>5.2.0</version>
    <scope>test</scope>
</dependency>
```

**Issues & Notes:**
- BOM declares Vertx 5.0.7 but codebase uses 4.x APIs
- Tests use JUnit 5 (project currently uses JUnit 4)
- Uses ArgumentCaptor to test callback handlers (POST endHandler pattern)

**Next:** apis-main tests coming in separate PR.